### PR TITLE
fix: malformed &nbsp HTML entities lack semicolons in header links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </h1>
 
 <p align="center">
-        🤗 <a href="https://huggingface.co/papers/2601.05242">Hugging Face Page</a>&nbsp&nbsp | &nbsp&nbsp 📄 <a href="https://arxiv.org/abs/2601.05242">Paper</a> | &nbsp&nbsp 📜 <a href="https://nvlabs.github.io/GDPO/">Page</a> &nbsp
+        🤗 <a href="https://huggingface.co/papers/2601.05242">Hugging Face Page</a>&nbsp;&nbsp; | &nbsp;&nbsp; 📄 <a href="https://arxiv.org/abs/2601.05242">Paper</a> | &nbsp;&nbsp; 📜 <a href="https://nvlabs.github.io/GDPO/">Page</a> &nbsp;
 </p>
 
 <h1 align="center"> 


### PR DESCRIPTION
### Problem
fix: malformed &nbsp HTML entities lack semicolons in header links

### Fix
Replace:
```
<a href="https://huggingface.co/papers/2601.05242">Hugging Face Page</a>&nbsp&nbsp | &nbsp&nbsp 📄 <a href="https://arxiv.org/abs/2601.05242">Paper</a> | &nbsp&nbsp 📜 <a href="https://nvlabs.github.io/GDPO/">Page</a> &nbsp
```

with:
```
<a href="https://huggingface.co/papers/2601.05242">Hugging Face Page</a>&nbsp;&nbsp; | &nbsp;&nbsp; 📄 <a href="https://arxiv.org/abs/2601.05242">Paper</a> | &nbsp;&nbsp; 📜 <a href="https://nvlabs.github.io/GDPO/">Page</a> &nbsp;
```

### Files changed
- `README.md`